### PR TITLE
Add configurable Gmsh path in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ All Python files now live in the repository root:
 1. Execute `python main.py` to launch the GUI.
 2. Adjust the PCB parameters as needed.
 3. Specify the output directory and file name.
-4. Click **Generate GMSH Script**. If *Open in Gmsh after generation* is checked, the file opens in Gmsh automatically.
+4. (Optional) Use **Browse...** next to *Gmsh Executable* to locate `gmsh` if it is not on your `PATH`. The selected path will be remembered.
+5. Click **Generate GMSH Script**. If *Open in Gmsh after generation* is checked, the file opens in Gmsh automatically.
 
 The generated script defines four volumes: the ground with vias, the trace, the surrounding air, and the dielectric. Comments in the file list these IDs for reference.
 

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,40 @@
 import os
 import platform
 import subprocess
+from typing import Optional
+
+CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".pcb_gmsh_gui")
 
 
-def open_gmsh_with_file(file_path: str) -> None:
+def load_last_gmsh_path() -> Optional[str]:
+    """Return the previously saved Gmsh executable path if available."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            path = f.read().strip()
+            return path or None
+    except OSError:
+        return None
+
+
+def save_last_gmsh_path(path: str) -> None:
+    """Persist the selected Gmsh executable path for future sessions."""
+    try:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            f.write(path)
+    except OSError:
+        pass
+
+
+def open_gmsh_with_file(file_path: str, gmsh_path: Optional[str] = None) -> None:
     """Try to open Gmsh with the given .geo file."""
     try:
+        if gmsh_path:
+            try:
+                subprocess.Popen([gmsh_path, file_path])
+                return
+            except (FileNotFoundError, subprocess.SubprocessError):
+                pass
+
         try:
             subprocess.Popen(["gmsh", file_path])
             return


### PR DESCRIPTION
## Summary
- allow selecting a Gmsh executable in the GUI
- remember the last chosen path
- support custom path when launching Gmsh
- document the new option in the README

## Testing
- `python -m py_compile *.py`
