### PR TITLE
Disable Gmsh GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All Python files now live in the repository root:
 2. Adjust the PCB parameters as needed.
 3. Specify the output directory and file name.
 4. (Optional) Use **Browse...** next to *Gmsh Executable* to locate `gmsh` if it is not on your `PATH`. The selected path will be remembered.
-5. Click **Generate GMSH Script**. If *Open in Gmsh after generation* is checked, the file opens in Gmsh automatically.
+5. Click **Generate GMSH Script**. If *Run Gmsh after generation* is checked, the file is processed by Gmsh in headless mode.
 
 The generated script defines four volumes: the ground with vias, the trace, the surrounding air, and the dielectric. Comments in the file list these IDs for reference.
 
@@ -32,12 +32,12 @@ A simple CLI is also available via `__main__.py`:
 python __main__.py -o pcb_model.geo [--open | --mesh] [--param value ...]
 ```
 
-Use `--mesh` to run Gmsh in batch mode so the `.msh` file is created without opening the Gmsh GUI.
+Both `--open` and `--mesh` run Gmsh in headless mode to generate the mesh without opening the Gmsh GUI.
 
 All parameters from `PCBParams` are available as flags (e.g. `--ground-size 15`). Use `--help` to see the full list of options.
 
-## Opening the file in Gmsh
-1. Open the generated `.geo` file in Gmsh (or let the GUI/CLI do this step).
+## Running the file in Gmsh
+1. You can still open the generated `.geo` file in Gmsh manually if you want to inspect it.
    The script now calls `Mesh 3;` to automatically generate a 3D mesh and save it as `pcb_model.msh`.
 
 ## Importing into Elmer

--- a/__main__.py
+++ b/__main__.py
@@ -20,7 +20,11 @@ def _add_param_arguments(parser: argparse.ArgumentParser) -> None:
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="PCB Gmsh Generator")
     parser.add_argument("-o", "--output", default="pcb_model.geo", help="Output .geo file")
-    parser.add_argument("--open", action="store_true", help="Open the result in Gmsh")
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Run Gmsh on the result without launching the GUI",
+    )
     parser.add_argument(
         "--mesh",
         action="store_true",

--- a/gui.py
+++ b/gui.py
@@ -96,7 +96,11 @@ class PCBGmshGUI:
         ttk.Button(output_frame, text="Browse...", command=self.browse_gmsh_executable).grid(row=2, column=2, padx=5, pady=5)
 
         self.open_in_gmsh = tk.BooleanVar(value=True)
-        ttk.Checkbutton(output_frame, text="Open in Gmsh after generation", variable=self.open_in_gmsh).grid(
+        ttk.Checkbutton(
+            output_frame,
+            text="Run Gmsh after generation",
+            variable=self.open_in_gmsh,
+        ).grid(
             row=3, column=0, columnspan=3, sticky=tk.W, padx=5, pady=5
         )
 

--- a/utils.py
+++ b/utils.py
@@ -26,38 +26,11 @@ def save_last_gmsh_path(path: str) -> None:
 
 
 def open_gmsh_with_file(file_path: str, gmsh_path: Optional[str] = None) -> None:
-    """Try to open Gmsh with the given .geo file."""
+    """Run Gmsh in headless mode with the given .geo file."""
     try:
-        if gmsh_path:
-            try:
-                subprocess.Popen([gmsh_path, file_path])
-                return
-            except (FileNotFoundError, subprocess.SubprocessError):
-                pass
-
-        try:
-            subprocess.Popen(["gmsh", file_path])
-            return
-        except (FileNotFoundError, subprocess.SubprocessError):
-            pass
-
-        if platform.system() == "Windows":
-            gmsh_exe_paths = [
-                r"E:\\Gmsh\\gmsh-4.13.1-Windows64\\gmsh-4.13.1-Windows64",
-                r"C:\\Program Files (x86)\\Gmsh\\gmsh.exe",
-                os.path.expanduser(r"~\\AppData\\Local\\Gmsh\\gmsh.exe"),
-            ]
-            for gmsh_path in gmsh_exe_paths:
-                if os.path.exists(gmsh_path):
-                    subprocess.Popen([gmsh_path, file_path])
-                    return
-        elif platform.system() == "Darwin":
-            subprocess.Popen(["open", "-a", "Gmsh", file_path])
-            return
-
-        print("Warning: Could not find Gmsh executable. Please open the file manually.")
+        run_gmsh_batch(file_path, gmsh_path)
     except Exception as exc:  # pragma: no cover - just logging
-        print(f"Warning: Failed to open Gmsh: {exc}\nPlease open the file manually.")
+        print(f"Warning: Failed to run Gmsh: {exc}\nPlease run Gmsh manually.")
 
 
 def run_gmsh_batch(file_path: str, gmsh_path: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary
- run gmsh via the command line instead of launching its GUI
- update help text in CLI and GUI
- document headless gmsh execution

## Testing
- `python -m py_compile $(ls *.py)`