### PR TITLE
Fix volume ID comments in gmsh generator

### DIFF
--- a/gmsh_generator.py
+++ b/gmsh_generator.py
@@ -149,8 +149,8 @@ Coherence;
 //------------------------- 4) Define Physical Volumes -------------------------//
 //   ground_vias[]  -> the union of ground plane + all vias (ID = 1)
 //   trace (which is volume #3, ID = 2)
-//   dielectric[]   -> new volume for the gap (ID = 4)
-//   air[]          -> bounding sphere minus the PCB (ID = 3)
+//   dielectric[]   -> new volume for the gap (ID = 3)
+//   air[]          -> bounding sphere minus the PCB (ID = 4)
 
 Physical Volume("Ground and Vias", 1) = {{ ground_vias[] }};
 Physical Volume("Trace", 2)          = {{ trace }};


### PR DESCRIPTION
## Summary
- correct the ID descriptions for dielectric and air volumes in `gmsh_generator.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6839feb5d8788327afc170ef82cd3916