### PR TITLE
Use UUID-based default output names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ All Python files now live in the repository root:
 ## Running the GUI
 1. Execute `python main.py` to launch the GUI.
 2. Adjust the PCB parameters as needed.
-3. Specify the output directory and file name.
+3. Specify the output directory and file name. By default a name like
+   `pcb_model_<uuid>.geo` is pre-filled.
 4. (Optional) Use **Browse...** next to *Gmsh Executable* to locate `gmsh` if it is not on your `PATH`. The selected path will be remembered.
 5. Click **Generate GMSH Script**. If *Run Gmsh after generation* is checked, the
    mesh is created in headless mode and you'll be notified once the `.msh` file is
-   written. Each run produces a uniquely named mesh such as
-   `mesh_<uuid>.msh`.
+   written. The mesh file uses the same base name as the `.geo` script, e.g.
+   `pcb_model_<uuid>.msh`.
 
 The generated script defines four volumes: the ground with vias, the trace, the surrounding air, and the dielectric. Comments in the file list these IDs for reference.
 
@@ -32,7 +33,7 @@ The generated script defines four volumes: the ground with vias, the trace, the 
 A simple CLI is also available via `__main__.py`:
 
 ```bash
-python __main__.py -o pcb_model.geo [--open | --mesh] [--param value ...]
+python __main__.py -o pcb_model_<uuid>.geo [--open | --mesh] [--param value ...]
 ```
 
 Both `--open` and `--mesh` run Gmsh in headless mode to generate the mesh without opening the Gmsh GUI.
@@ -41,9 +42,10 @@ All parameters from `PCBParams` are available as flags (e.g. `--ground-size 15`)
 
 ## Running the file in Gmsh
 1. You can still open the generated `.geo` file in Gmsh manually if you want to inspect it.
-   The script now calls `Mesh 3;` to automatically generate a 3D mesh and save it as `pcb_model.msh`.
+   The script now calls `Mesh 3;` to automatically generate a 3D mesh and save it
+   alongside the script as `<output_basename>.msh`.
 
 ## Importing into Elmer
-1. Convert the mesh using `ElmerGrid 4 2 pcb_model.msh`.
+1. Convert the mesh using `ElmerGrid 4 2 <output_basename>.msh`.
 2. Open the generated mesh directory in ElmerGUI or reference it in your simulation setup.
 3. Assign bodies according to the volume IDs noted in the `.geo` file.

--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import uuid
 
 from config import PCBParams
 from gmsh_generator import generate_geo
@@ -19,7 +20,8 @@ def _add_param_arguments(parser: argparse.ArgumentParser) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="PCB Gmsh Generator")
-    parser.add_argument("-o", "--output", default="pcb_model.geo", help="Output .geo file")
+    default_name = f"pcb_model_{uuid.uuid4().hex}.geo"
+    parser.add_argument("-o", "--output", default=default_name, help="Output .geo file")
     parser.add_argument(
         "--open",
         action="store_true",

--- a/gui.py
+++ b/gui.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 
@@ -83,7 +84,8 @@ class PCBGmshGUI:
         output_frame.pack(fill=tk.X, padx=5, pady=5)
 
         ttk.Label(output_frame, text="Output File:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
-        self.output_file = tk.StringVar(value="pcb_model.geo")
+        default_name = f"pcb_model_{uuid.uuid4().hex}.geo"
+        self.output_file = tk.StringVar(value=default_name)
         ttk.Entry(output_frame, textvariable=self.output_file, width=30).grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
 
         ttk.Label(output_frame, text="Output Directory:").grid(row=1, column=0, sticky=tk.W, padx=5, pady=5)

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import subprocess
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -92,8 +91,8 @@ def run_gmsh(
 ) -> Path:
     """Run Gmsh on ``geo_file`` and return the generated ``.msh`` path."""
 
-    unique_name = f"mesh_{uuid.uuid4().hex}.msh"
-    output_path = Path(output_dir) / unique_name
+    base_name = Path(geo_file).stem
+    output_path = Path(output_dir) / f"{base_name}.msh"
 
     args = [geo_file, "-3", "-o", str(output_path)]
 


### PR DESCRIPTION
## Summary
- generate unique filenames by default when running CLI or GUI
- keep mesh filenames consistent with the `.geo` basename
- document new naming behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6839feba4e9083278d67cbe1297be66d