### PR TITLE
Switch to timestamp output names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ All Python files now live in the repository root:
 1. Execute `python main.py` to launch the GUI.
 2. Adjust the PCB parameters as needed.
 3. Specify the output directory and file name. By default a name like
-   `pcb_model_<uuid>.geo` is pre-filled.
+   `pcb_model_<timestamp>.geo` (e.g. `pcb_model_20240108_142500.geo`) is pre-filled.
 4. (Optional) Use **Browse...** next to *Gmsh Executable* to locate `gmsh` if it is not on your `PATH`. The selected path will be remembered.
 5. Click **Generate GMSH Script**. If *Run Gmsh after generation* is checked, the
    mesh is created in headless mode and you'll be notified once the `.msh` file is
    written. The mesh file uses the same base name as the `.geo` script, e.g.
-   `pcb_model_<uuid>.msh`.
+   `pcb_model_<timestamp>.msh`.
 
 The generated script defines four volumes: the ground with vias, the trace, the surrounding air, and the dielectric. Comments in the file list these IDs for reference.
 
@@ -33,7 +33,7 @@ The generated script defines four volumes: the ground with vias, the trace, the 
 A simple CLI is also available via `__main__.py`:
 
 ```bash
-python __main__.py -o pcb_model_<uuid>.geo [--open | --mesh] [--param value ...]
+python __main__.py -o pcb_model_<timestamp>.geo [--open | --mesh] [--param value ...]
 ```
 
 Both `--open` and `--mesh` run Gmsh in headless mode to generate the mesh without opening the Gmsh GUI.

--- a/__main__.py
+++ b/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-import uuid
+from datetime import datetime
 
 from config import PCBParams
 from gmsh_generator import generate_geo
@@ -20,7 +20,8 @@ def _add_param_arguments(parser: argparse.ArgumentParser) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="PCB Gmsh Generator")
-    default_name = f"pcb_model_{uuid.uuid4().hex}.geo"
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    default_name = f"pcb_model_{timestamp}.geo"
     parser.add_argument("-o", "--output", default=default_name, help="Output .geo file")
     parser.add_argument(
         "--open",

--- a/gui.py
+++ b/gui.py
@@ -1,5 +1,5 @@
 import os
-import uuid
+from datetime import datetime
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 
@@ -84,7 +84,8 @@ class PCBGmshGUI:
         output_frame.pack(fill=tk.X, padx=5, pady=5)
 
         ttk.Label(output_frame, text="Output File:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
-        default_name = f"pcb_model_{uuid.uuid4().hex}.geo"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        default_name = f"pcb_model_{timestamp}.geo"
         self.output_file = tk.StringVar(value=default_name)
         ttk.Entry(output_frame, textvariable=self.output_file, width=30).grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
 


### PR DESCRIPTION
## Summary
- use timestamps rather than UUIDs for default output names
- update README examples

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683a10b3c3d48327acd390dbdf787bfe