### PR TITLE
Improve ElmerGUI error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A simple CLI is also available via `__main__.py`:
 python __main__.py -o pcb_model_<timestamp>.geo [--open | --mesh | --elmergrid] [--param value ...]
 ```
 
-Both `--open` and `--mesh` run Gmsh in headless mode to generate the mesh without opening the Gmsh GUI. Use `--elmergrid` to launch `ElmerGUI` with the resulting `.msh` file.
+Both `--open` and `--mesh` run Gmsh in headless mode to generate the mesh without opening the Gmsh GUI. Use `--elmergrid` to launch `ElmerGUI` with the resulting `.msh` file. Add `--elmer-verbose` to capture any messages printed by ElmerGUI.
 
 All parameters from `PCBParams` are available as flags (e.g. `--ground-size 15`). Use `--help` to see the full list of options.
 
@@ -51,4 +51,5 @@ All parameters from `PCBParams` are available as flags (e.g. `--ground-size 15`)
 ## Importing into Elmer
 
 1. Run the CLI with `--elmergrid` (or launch `ElmerGUI` manually) to open the generated `.msh` file directly in ElmerGUI.
-2. Assign bodies according to the volume IDs noted in the `.geo` file.
+2. If ElmerGUI crashes, re-run the command with `--elmer-verbose` to capture its output.
+3. Assign bodies according to the volume IDs noted in the `.geo` file.

--- a/__main__.py
+++ b/__main__.py
@@ -43,6 +43,11 @@ def main(argv: list[str] | None = None) -> None:
         default="",
         help="Path to the ElmerGrid executable (used to locate ElmerGUI)",
     )
+    parser.add_argument(
+        "--elmer-verbose",
+        action="store_true",
+        help="Capture verbose output from ElmerGUI",
+    )
     parser.add_argument("--gui", action="store_true", help="Launch GUI instead of CLI")
     _add_param_arguments(parser)
     args = parser.parse_args(argv)
@@ -61,7 +66,11 @@ def main(argv: list[str] | None = None) -> None:
     if mesh_needed:
         mesh_path = run_gmsh(str(output_path), output_path.parent)
         if args.elmergrid:
-            run_elmer_gui(str(mesh_path), args.elmer_exe or None)
+            output = run_elmer_gui(
+                str(mesh_path), args.elmer_exe or None, verbose=args.elmer_verbose
+            )
+            if output.strip():
+                print("ElmerGUI output:\n" + output)
     elif args.open:
         open_gmsh_with_file(str(output_path))
 

--- a/gui.py
+++ b/gui.py
@@ -219,7 +219,11 @@ class PCBGmshGUI:
                     if elmer_path:
                         save_last_elmer_path(elmer_path)
                     try:
-                        run_elmer_gui(str(mesh_path), elmer_path)
+                        output = run_elmer_gui(
+                            str(mesh_path), elmer_path, verbose=True
+                        )
+                        if output.strip():
+                            messagebox.showinfo("ElmerGUI Output", output)
                     except Exception as exc:
                         messagebox.showerror("Error", f"Failed to run ElmerGUI: {exc}")
                 except Exception as exc:


### PR DESCRIPTION
## Summary
- add `--elmer-verbose` CLI option
- capture ElmerGUI stdout/stderr and show it in GUI or print to CLI
- document how to capture ElmerGUI output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f508163e88327aff8e0eda71d5d37